### PR TITLE
Layer typings

### DIFF
--- a/@types/ol/layer/BaseImage.d.ts
+++ b/@types/ol/layer/BaseImage.d.ts
@@ -7,7 +7,7 @@ import RenderEvent from '../render/Event';
 import ImageSource from '../source/Image';
 import Layer from './Layer';
 
-export interface Options {
+export interface Options<ImageSourceType extends ImageSource> {
     className?: string;
     opacity?: number;
     visible?: boolean;
@@ -18,10 +18,10 @@ export interface Options {
     minZoom?: number;
     maxZoom?: number;
     map?: PluggableMap;
-    source?: ImageSource;
+    source?: ImageSourceType;
 }
-export default class BaseImageLayer extends Layer<ImageSource> {
-    constructor(opt_options?: Options & { [key: string]: any });
+export default class BaseImageLayer<ImageSourceType extends ImageSource = ImageSource> extends Layer<ImageSourceType> {
+    constructor(opt_options?: Options<ImageSourceType> & { [key: string]: any });
     on(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];
     once(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];
     un(type: string | string[], listener: (p0: any) => any): void;

--- a/@types/ol/layer/BaseTile.d.ts
+++ b/@types/ol/layer/BaseTile.d.ts
@@ -7,7 +7,7 @@ import RenderEvent from '../render/Event';
 import TileSource from '../source/Tile';
 import Layer from './Layer';
 
-export interface Options {
+export interface Options<TileSourceType extends TileSource> {
     className?: string;
     opacity?: number;
     visible?: boolean;
@@ -18,12 +18,12 @@ export interface Options {
     minZoom?: number;
     maxZoom?: number;
     preload?: number;
-    source?: TileSource;
+    source?: TileSourceType;
     map?: PluggableMap;
     useInterimTilesOnError?: boolean;
 }
-export default class BaseTileLayer extends Layer<TileSource> {
-    constructor(opt_options?: Options & { [key: string]: any });
+export default class BaseTileLayer<TileSourceType extends TileSource = TileSource> extends Layer<TileSourceType> {
+    constructor(opt_options?: Options<TileSourceType> & { [key: string]: any });
     /**
      * Return the level as number to which we will preload tiles up to.
      */

--- a/@types/ol/layer/BaseVector.d.ts
+++ b/@types/ol/layer/BaseVector.d.ts
@@ -13,7 +13,7 @@ import VectorTile from '../source/VectorTile';
 import { StyleFunction, StyleLike } from '../style/Style';
 import Layer from './Layer';
 
-export interface Options {
+export interface Options<VectorSourceType extends VectorSource | VectorTile> {
     className?: string;
     opacity?: number;
     visible?: boolean;
@@ -35,7 +35,7 @@ export interface Options {
 export default class BaseVectorLayer<
     VectorSourceType extends VectorSource | VectorTile = VectorSource | VectorTile
 > extends Layer<VectorSourceType> {
-    constructor(opt_options?: Options & { [key: string]: any });
+    constructor(opt_options?: Options<VectorSourceType> & { [key: string]: any });
     getDeclutter(): boolean;
     /**
      * Get the topmost feature that intersects the given pixel on the viewport. Returns a promise

--- a/@types/ol/layer/Graticule.d.ts
+++ b/@types/ol/layer/Graticule.d.ts
@@ -9,6 +9,7 @@ import RenderEvent from '../render/Event';
 import Stroke from '../style/Stroke';
 import Text from '../style/Text';
 import VectorLayer from './Vector';
+import VectorSource from 'ol/source/Vector';
 
 export interface GraticuleLabelDataType {
     geom: Point;
@@ -37,7 +38,7 @@ export interface Options {
     intervals?: number[];
     wrapX?: boolean;
 }
-export default class Graticule extends VectorLayer {
+export default class Graticule extends VectorLayer<VectorSource> {
     constructor(opt_options?: Options & { [key: string]: any });
     /**
      * Get the list of meridians.  Meridians are lines of equal longitude.

--- a/@types/ol/layer/Image.d.ts
+++ b/@types/ol/layer/Image.d.ts
@@ -3,16 +3,16 @@ import BaseEvent from '../events/Event';
 import { ObjectEvent } from '../Object';
 import RenderEvent from '../render/Event';
 import LayerRenderer from '../renderer/Layer';
-import Source from '../source/Source';
 import BaseImageLayer, { Options } from './BaseImage';
 import Layer from './Layer';
+import ImageSource from '../source/Image';
 
-export default class ImageLayer extends BaseImageLayer {
-    constructor(opt_options?: Options & { [key: string]: any });
+export default class ImageLayer<ImageSourceType extends ImageSource = ImageSource> extends BaseImageLayer<ImageSourceType> {
+    constructor(opt_options?: Options<ImageSourceType> & { [key: string]: any });
     /**
      * Create a renderer for this layer.
      */
-    createRenderer(): LayerRenderer<Layer<Source>>;
+    createRenderer(): LayerRenderer<Layer>;
     on(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];
     once(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];
     un(type: string | string[], listener: (p0: any) => any): void;

--- a/@types/ol/layer/Layer.d.ts
+++ b/@types/ol/layer/Layer.d.ts
@@ -8,12 +8,12 @@ import { Pixel } from '../pixel';
 import PluggableMap, { FrameState } from '../PluggableMap';
 import RenderEvent from '../render/Event';
 import LayerRenderer from '../renderer/Layer';
-import Source from '../source/Source';
 import State_1 from '../source/State';
 import { State as State_2 } from '../View';
 import BaseLayer from './Base';
+import Source from '../source/Source';
 
-export interface Options {
+export interface Options<SourceType extends Source> {
     className?: string;
     opacity?: number;
     visible?: boolean;
@@ -23,13 +23,13 @@ export interface Options {
     maxResolution?: number;
     minZoom?: number;
     maxZoom?: number;
-    source?: Source;
+    source?: SourceType;
     map?: PluggableMap;
     render?: RenderFunction;
 }
 export type RenderFunction = (p0: FrameState) => HTMLElement;
 export interface State {
-    layer: Layer<Source>;
+    layer: Layer;
     opacity: number;
     sourceState: State_1;
     visible: boolean;
@@ -42,22 +42,22 @@ export interface State {
     maxZoom: number;
 }
 export default class Layer<SourceType extends Source = Source> extends BaseLayer {
-    constructor(options: Options);
+    constructor(options: Options<SourceType>);
     /**
      * Create a renderer for this layer.
      */
-    protected createRenderer(): LayerRenderer<Layer<Source>>;
+    protected createRenderer(): LayerRenderer<Layer>;
     /**
      * Clean up.
      */
     disposeInternal(): void;
     getFeatures(pixel: Pixel): Promise<Feature<Geometry>[]>;
-    getLayersArray(opt_array?: Layer<Source>[]): Layer<Source>[];
+    getLayersArray(opt_array?: Layer<SourceType>[]): Layer<SourceType>[];
     getLayerStatesArray(opt_states?: State[]): State[];
     /**
      * Get the renderer for this layer.
      */
-    getRenderer(): LayerRenderer<Layer<Source>>;
+    getRenderer(): LayerRenderer<Layer>;
     /**
      * Get the layer source.
      */

--- a/@types/ol/layer/Tile.d.ts
+++ b/@types/ol/layer/Tile.d.ts
@@ -3,16 +3,16 @@ import BaseEvent from '../events/Event';
 import { ObjectEvent } from '../Object';
 import RenderEvent from '../render/Event';
 import LayerRenderer from '../renderer/Layer';
-import Source from '../source/Source';
 import BaseTileLayer, { Options } from './BaseTile';
 import Layer from './Layer';
+import TileSource from '../source/Tile';
 
-export default class TileLayer extends BaseTileLayer {
-    constructor(opt_options?: Options & { [key: string]: any });
+export default class TileLayer<TileSourceType extends TileSource = TileSource> extends BaseTileLayer<TileSourceType> {
+    constructor(opt_options?: Options<TileSourceType> & { [key: string]: any });
     /**
      * Create a renderer for this layer.
      */
-    protected createRenderer(): LayerRenderer<Layer<Source>>;
+    protected createRenderer(): LayerRenderer<Layer>;
     on(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];
     once(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];
     un(type: string | string[], listener: (p0: any) => any): void;

--- a/@types/ol/layer/Vector.d.ts
+++ b/@types/ol/layer/Vector.d.ts
@@ -3,17 +3,16 @@ import BaseEvent from '../events/Event';
 import { ObjectEvent } from '../Object';
 import RenderEvent from '../render/Event';
 import LayerRenderer from '../renderer/Layer';
-import Source from '../source/Source';
 import VectorSource from '../source/Vector';
 import BaseVectorLayer, { Options } from './BaseVector';
 import Layer from './Layer';
 
-export default class VectorLayer extends BaseVectorLayer<VectorSource> {
-    constructor(opt_options?: Options & { [key: string]: any });
+export default class VectorLayer<VectorSourceType extends VectorSource = VectorSource> extends BaseVectorLayer<VectorSourceType> {
+    constructor(opt_options?: Options<VectorSourceType> & { [key: string]: any });
     /**
      * Create a renderer for this layer.
      */
-    createRenderer(): LayerRenderer<Layer<Source>>;
+    createRenderer(): LayerRenderer<Layer>;
     on(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];
     once(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];
     un(type: string | string[], listener: (p0: any) => any): void;

--- a/@types/ol/layer/VectorImage.d.ts
+++ b/@types/ol/layer/VectorImage.d.ts
@@ -1,19 +1,17 @@
 import { EventsKey } from '../events';
 import BaseEvent from '../events/Event';
 import { Extent } from '../extent';
-import Geometry from '../geom/Geometry';
 import { ObjectEvent } from '../Object';
 import PluggableMap from '../PluggableMap';
 import { OrderFunction } from '../render';
 import RenderEvent from '../render/Event';
 import LayerRenderer from '../renderer/Layer';
-import Source from '../source/Source';
 import VectorSource from '../source/Vector';
 import { StyleLike } from '../style/Style';
 import BaseVectorLayer from './BaseVector';
 import Layer from './Layer';
 
-export interface Options {
+export interface Options<VectorSourceType extends VectorSource> {
     className?: string;
     opacity?: number;
     visible?: boolean;
@@ -25,18 +23,18 @@ export interface Options {
     maxZoom?: number;
     renderOrder?: OrderFunction;
     renderBuffer?: number;
-    source?: VectorSource<Geometry>;
+    source?: VectorSourceType;
     map?: PluggableMap;
     declutter?: boolean;
     style?: StyleLike;
     imageRatio?: number;
 }
-export default class VectorImageLayer extends BaseVectorLayer {
-    constructor(opt_options?: Options & { [key: string]: any });
+export default class VectorImageLayer<VectorSourceType extends VectorSource = VectorSource> extends BaseVectorLayer {
+    constructor(opt_options?: Options<VectorSourceType> & { [key: string]: any });
     /**
      * Create a renderer for this layer.
      */
-    createRenderer(): LayerRenderer<Layer<Source>>;
+    createRenderer(): LayerRenderer<Layer>;
     getImageRatio(): number;
     on(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];
     once(type: string | string[], listener: (p0: any) => any): EventsKey | EventsKey[];

--- a/@types/ol/layer/VectorTile.d.ts
+++ b/@types/ol/layer/VectorTile.d.ts
@@ -9,7 +9,6 @@ import PluggableMap from '../PluggableMap';
 import { OrderFunction } from '../render';
 import RenderEvent from '../render/Event';
 import LayerRenderer from '../renderer/Layer';
-import Source from '../source/Source';
 import VectorTile from '../source/VectorTile';
 import { StyleLike } from '../style/Style';
 import BaseVectorLayer from './BaseVector';
@@ -43,7 +42,7 @@ export default class VectorTileLayer extends BaseVectorLayer<VectorTile> {
     /**
      * Create a renderer for this layer.
      */
-    protected createRenderer(): LayerRenderer<Layer<Source>>;
+    protected createRenderer(): LayerRenderer<Layer>;
     /**
      * Get the topmost feature that intersects the given pixel on the viewport. Returns a promise
      * that resolves with an array of features. The array will either contain the topmost feature

--- a/@types/ol/layer/WebGLPoints.d.ts
+++ b/@types/ol/layer/WebGLPoints.d.ts
@@ -1,7 +1,6 @@
 import { EventsKey } from '../events';
 import BaseEvent from '../events/Event';
 import { Extent } from '../extent';
-import Geometry from '../geom/Geometry';
 import { ObjectEvent } from '../Object';
 import RenderEvent from '../render/Event';
 import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer';
@@ -9,7 +8,7 @@ import VectorSource from '../source/Vector';
 import { LiteralStyle } from '../style/LiteralStyle';
 import Layer from './Layer';
 
-export interface Options {
+export interface Options<VectorSourceType extends VectorSource> {
     style: LiteralStyle;
     className?: string;
     opacity?: number;
@@ -20,11 +19,11 @@ export interface Options {
     maxResolution?: number;
     minZoom?: number;
     maxZoom?: number;
-    source?: VectorSource<Geometry>;
+    source?: VectorSourceType;
     disableHitDetection?: boolean;
 }
-export default class WebGLPointsLayer extends Layer {
-    constructor(options: Options);
+export default class WebGLPointsLayer<VectorSourceType extends VectorSource = VectorSource> extends Layer<VectorSourceType> {
+    constructor(options: Options<VectorSourceType>);
     /**
      * Create a renderer for this layer.
      */


### PR DESCRIPTION
Hey, while using your project and also fiddling around with auto generating the type definitions directly from the openlayers source, I found some problems with the generic types of the layers.

I fixed most of them already in the jsdoc typings (see https://github.com/openlayers/openlayers/pull/11948) and I work on making the automatically generated typings better to begin with. If you have any suggestions what would be nice if it was already fixed upstream, let me know.

Also it would be really great if you could do a new release? In the current version on npm the `ImageLayer` and `BaseImageLayer` are broken.